### PR TITLE
fix: adjust account data slicing for unpack (follow-up to #2)

### DIFF
--- a/saros-dlmm/src/amms/test_harness.rs
+++ b/saros-dlmm/src/amms/test_harness.rs
@@ -53,7 +53,7 @@ pub const MASHA_MINT: Pubkey = pubkey!("mae8vJGf8Wju8Ron1oDTQVaTGGBpcpWDwoRQJALM
 lazy_static! {
     // For SwapMode::ExactIn
     pub static ref TOKEN_MINT_AND_IN_AMOUNT: [(Pubkey, u64); 5] = [
-        (spl_token::native_mint::ID, 25_000_000_000),
+        (spl_token::native_mint::ID, 2_500_000_000),
         (SAROS_MINT, 1_000_000_000),
         (MASHA_MINT, 1_000_000_000),
         (USDC_MINT, 1_110_000_000),

--- a/saros-dlmm/src/lib.rs
+++ b/saros-dlmm/src/lib.rs
@@ -77,7 +77,7 @@ impl Amm for SarosDlmm {
     where
         Self: Sized,
     {
-        let account_data = &keyed_account.account.data[8..];
+        let account_data = &keyed_account.account.data[..];
         let pair = Pair::unpack(&account_data)?;
 
         let bin_array_index = pair.bin_array_index();
@@ -101,7 +101,7 @@ impl Amm for SarosDlmm {
         Ok(Self {
             program_id: keyed_account.account.owner,
             key: keyed_account.key,
-            label: "saros_dlmm"[..].to_string(),
+            label: "saros_dlmm".into(),
             pair,
             token_transfer_fee: TokenTransferFee::default(),
             bin_array_lower: BinArray::default(),
@@ -131,10 +131,10 @@ impl Amm for SarosDlmm {
 
     fn update(&mut self, account_map: &AccountMap) -> Result<()> {
         let bin_array_lower_data = try_get_account_data(account_map, &self.bin_array_key[0])?;
-        let bin_array_lower = &BinArray::unpack(&bin_array_lower_data[8..])?;
+        let bin_array_lower = &BinArray::unpack(&bin_array_lower_data[..])?;
 
         let bin_array_upper_data = try_get_account_data(account_map, &self.bin_array_key[1])?;
-        let bin_array_upper = &BinArray::unpack(&bin_array_upper_data[8..])?;
+        let bin_array_upper = &BinArray::unpack(&bin_array_upper_data[..])?;
 
         let (mint_x_data, mint_x_owner) =
             try_get_account_data_and_owner(account_map, &self.pair.token_mint_x)?;


### PR DESCRIPTION
Fixes an unpacking issue introduced in https://github.com/saros-xyz/saros-dlmm-sdk-rs/pull/2.

One small issue: the unpacking logic currently assumes the account data starts at offset 0 (i.e., includes the 8-byte Anchor discriminator).
However, in our SDK we slice that off with data[8..] before calling unpack(), so this logic breaks.

This PR adjusts the slicing to ensure correct deserialization.