### PR TITLE
fix: handling memory allocation failed when swapping across multiple bins.

### DIFF
--- a/saros-dlmm/src/constants.rs
+++ b/saros-dlmm/src/constants.rs
@@ -5,3 +5,4 @@ pub const PRECISION: u64 = 1_000_000_000;
 pub const SQUARED_PRECISION: u128 = 1_000_000_000_000_000_000;
 pub const MAX_ACTIVE_ID: u32 = 16_777_215; // 2^24 - 1
 pub const MIDDLE_BIN_ID: i32 = 8_388_608; // 2^23
+pub const MAX_BIN_CROSSING: u32 = 30; // Maximum number of bins that can be crossed in a swap

--- a/saros-dlmm/src/errors.rs
+++ b/saros-dlmm/src/errors.rs
@@ -47,6 +47,9 @@ pub enum ErrorCode {
 
     #[error("U64 conversion overflow")]
     U64ConversionOverflow, // 0x177e
+
+    #[error("Swap crosses too many bins – quote aborted")]
+    SwapCrossesTooManyBins,
 }
 
 impl From<TryFromIntError> for ErrorCode {


### PR DESCRIPTION
This pull request introduces a safeguard in the swap logic to prevent swaps from crossing an excessive number of bins, which helps mitigate potential performance issues or attacks. The main changes add a maximum limit to how many bins a swap operation can traverse, and return a specific error if this limit is exceeded.

**Swap bin crossing restriction:**

* Added a new constant `MAX_BIN_CROSSING` in `constants.rs` to define the maximum number of bins a swap can cross (`MAX_BIN_CROSSING: u32 = 30`).
* Introduced a new error variant `SwapCrossesTooManyBins` in the `ErrorCode` enum to signal when the bin crossing limit is exceeded.

**Swap logic enforcement:**

* Updated `get_swap_result` in `swap_manager.rs` to track the number of bins crossed during a swap and return the new error if the limit is reached, for both input and output swap directions. [[1]](diffhunk://#diff-f8ce63de941da8c214e9ceb3ac36244dffe4073537d097a6133ef7af06d37ac8R26-R31) [[2]](diffhunk://#diff-f8ce63de941da8c214e9ceb3ac36244dffe4073537d097a6133ef7af06d37ac8R69-R70) [[3]](diffhunk://#diff-f8ce63de941da8c214e9ceb3ac36244dffe4073537d097a6133ef7af06d37ac8R81-R86) [[4]](diffhunk://#diff-f8ce63de941da8c214e9ceb3ac36244dffe4073537d097a6133ef7af06d37ac8R124)
* Imported the new `MAX_BIN_CROSSING` constant into `swap_manager.rs`.