### PR TITLE
docs(dlmm-rs): add audit findings and PoC references 

### DIFF
--- a/docs/audit/PR_BODY.md
+++ b/docs/audit/PR_BODY.md
@@ -1,0 +1,6 @@
+Title: DLMM Rust SDK: tests and findings (no code changes)
+
+Summary
+This PR adds audit documentation and test references for the 64.64 math and related paths. It does not modify production code.
+
+Please see FINDINGS.md in the root repo and PoC tests under tests/ in the audit repo.


### PR DESCRIPTION
Title: DLMM Rust SDK: tests and findings 

Summary
This PR adds audit documentation and test references for the 64.64 math and related paths. It does not modify production code.

Please see FINDINGS.md in the root repo and PoC tests under tests/ in the audit repo.
