### PR TITLE
Fix test assertions and potential panics in math module

### DIFF
--- a/saros-dlmm/src/amms/test_harness.rs
+++ b/saros-dlmm/src/amms/test_harness.rs
@@ -557,7 +557,7 @@ impl AmmTestHarness {
         );
 
         let file =
-            File::open(&file_path).unwrap_or_else(|_| panic!("Snapshot file {file_path} exists"));
+            File::open(&file_path).unwrap_or_else(|_| panic!("Snapshot file {file_path} does not exist"));
         let keyed_account: RpcKeyedAccount = serde_json::from_reader(file).unwrap();
         let account: Account = UiAccount::decode(&keyed_account.account).unwrap();
         let params_file_path = format!("tests/fixtures/accounts/{0}/params.json", directory_name);

--- a/saros-dlmm/src/math/u128x128_math.rs
+++ b/saros-dlmm/src/math/u128x128_math.rs
@@ -124,7 +124,7 @@ mod fuzz_tests {
         fn test_most_significant_bit(x: u128) {
             let msb = most_significant_bit(x);
 
-            assert!(1 << msb < x);
+            assert!(1 << msb <= x);
 
             if msb < 127 {
                 assert!(1 << (msb + 1) > x);


### PR DESCRIPTION
## Summary
Found 6 bugs ranging from Minor to Critical severity, including potential panic points and integer overflow issues. Bugs No. 1 and No. 2 have been patched directly in this PR.

## Bug No. 1: Incorrect Test Assertion for Powers of 2 in most_significant_bit Function (PATCHED)

### Severity: Medium

### Location
`saros-dlmm/src/math/u128x128_math.rs:127`

### Description
The test assertion for the `most_significant_bit` function fails for all powers of 2. The assertion `assert!(1 << msb < x)` is mathematically incorrect when `x` is a power of 2.

### Expected vs Actual Behavior
- Expected: Test should pass for all valid u128 values including powers of 2
- Actual: Test fails when x = 2^n for any n

### Root Cause
When x = 2^n:
- The MSB function correctly returns n
- However, 1 << n equals 2^n, which equals x
- Therefore 1 << msb < x evaluates to false (since 2^n is not less than 2^n)

### Fix Applied
Changed the assertion from `assert!(1 << msb < x)` to `assert!(1 << msb <= x)` in line 127.

### Impact
- Causes proptest/fuzz testing to fail when powers of 2 are randomly selected as test inputs
- Could mask other potential bugs in the MSB function due to failing tests

---

## Bug No. 2: Misleading Error Message in Test Harness File Opening (PATCHED)

### Severity: Minor

### Location
`saros-dlmm/src/amms/test_harness.rs:560`

### Description
The error message when failing to open a snapshot file incorrectly states "Snapshot file exists" when the file actually does not exist.

### Expected vs Actual Behavior
- Expected: Error message should say "Snapshot file does not exist" when File::open fails
- Actual: Error message says "Snapshot file exists" when file is missing

### Root Cause
Logic error in the error message - the unwrap_or_else closure is triggered when File::open fails (typically because the file doesn't exist), but the panic message suggests the opposite.

### Fix Applied
Changed the error message from "exists" to "does not exist" in line 560.

### Impact
- Causes confusion when debugging test failures
- Makes it harder to identify the actual problem when snapshot files are missing

---

## Reproduction Steps

### For Bug No. 1:
The proptest in `cargo test test_most_significant_bit` may not always catch this bug due to random value generation. To reliably reproduce:

Create and run this test file:
```rust
// test_bug1.rs
fn most_significant_bit(x: u128) -> u8 {
    // ... implementation from u128x128_math.rs ...
}

fn main() {
    for i in 0..10 {
        let x = 1u128 << i;  // Powers of 2
        let msb = most_significant_bit(x);
        assert!(1 << msb < x);  // This FAILS for all powers of 2!
    }
}
```

The assertion assert!(1 << msb < x) fails for ALL powers of 2 because when x = 2^n, then msb = n and 1 << n = 2^n = x, so the condition 1 << msb < x is false.

### For Bug No. 2:
```bash
cd saros-dlmm
cargo test test_amms
```
The test will panic with misleading error messages about files "existing" when they actually don't.

## Environment Details
- OS: Linux 6.14.0-29-generic
- Rust: Latest stable
- SDK Version: Current main branch (commit e9a2f49)

---

## Bug No. 3: Potential Panic in `get_protocol_fee` with Invalid Input

### Severity: Medium

### Location
`saros-dlmm/src/math/utils.rs:7`

### Description
While the function works correctly under normal conditions (protocol_share ≤ 100%), it uses `unwrap()` on a `try_from` conversion that can panic with abnormal inputs.

### Code
```rust
pub fn get_protocol_fee(fee: u64, protocol_share: u64) -> u64 {
    u64::try_from(u128::from(fee) * u128::from(protocol_share) / u128::from(BASIS_POINT_MAX))
        .unwrap()  // Can panic if protocol_share > BASIS_POINT_MAX
}
```

### Analysis
I understand this function operates correctly when protocol_share is within normal bounds (10,000 or less, representing 100% or less). However, the function can still panic with invalid inputs where protocol_share exceeds 10,000.

### Impact
- Works fine with normal protocol_share values (100% or less)
- Can panic with malicious or erroneous inputs
- Lacks defensive programming against invalid parameters
- No input validation or graceful error handling

### Fix
Add input validation or use saturating arithmetic to prevent panics from invalid inputs.

---

## Bug No. 4: Multiple Unwrap Panics in `get_price_from_id`

### Severity: Critical

### Location
`saros-dlmm/src/math/bin_math.rs:6-12`

### Description
The function has 4 unwrap() calls, with 2 that actually cause panics in practice.

### Code
```rust
pub fn get_price_from_id(bin_step: u8, id: u32) -> u128 {
    let base = get_base(bin_step).unwrap();        // Safe but bad practice
    let exponent = i32::try_from(id)
        .unwrap()                                   // PANIC: if id > i32::MAX
        .checked_sub(MIDDLE_BIN_ID)
        .unwrap();                                  // Safe for valid ids
    pow(base, exponent).unwrap()                   // PANIC: extreme exponents
}
```

### Verified Failure Cases
1. id > 2,147,483,647 - Panics on u32 to i32 conversion
2. id near 0 or MAX_ACTIVE_ID - Exponent exceeds MAX_EXPONENTIAL (524,288)
3. Actual working range: Only approximately 1M values around MIDDLE_BIN_ID ± 524k work (6% of valid range)

### Impact
- Function accepts any u32 but panics for most inputs
- No input validation whatsoever
- Can crash the entire program

---

## Bug No. 5: Mathematical Design Flaw - Extreme Exponent Values

### Severity: High

### Location
`saros-dlmm/src/math/bin_math.rs` and `u64x64_math.rs`

### Description
The mathematical model breaks down for extreme id values, creating exponents that far exceed the safe operating range.

### Analysis
- Documented safe range: ±443,636
- Code MAX_EXPONENTIAL: 524,288
- Actual exponent range: ±8,388,608 (16x larger)
- When id = 0: exponent = -8,388,608
- When id = MAX_ACTIVE_ID (16,777,215): exponent = 8,388,607

### Root Cause
The design assumes IDs near MIDDLE_BIN_ID but allows the full range 0 to MAX_ACTIVE_ID, creating mathematically invalid scenarios.

### Impact
- Even if unwrap() is handled (Bug No. 4), the math is fundamentally wrong
- Leads to incorrect price calculations or overflows
- This is a design flaw, not just a coding error

---

## Bug No. 6: ID Range Validation Inconsistency

### Severity: High

### Location
`saros-dlmm/src/math/bin_math.rs` and throughout the codebase

### Description
Severe API inconsistency where different parts of the code have different assumptions about valid ID ranges.

### The Conflicting Ranges
1. Function accepts: 0 to 4,294,967,295 (any u32)
2. MAX_ACTIVE_ID suggests: 0 to 16,777,215
3. Actually works without panic: 7,864,320 to 8,912,896 (approximately 1M values, only 6% of "valid" range)

### Evidence
- get_price_from_id: No validation, accepts any u32
- move_active_id_right: Validates id < MAX_ACTIVE_ID
- Most "valid" IDs (per MAX_ACTIVE_ID) actually cause panics

### Impact
- Users expect function to handle 0 to MAX_ACTIVE_ID
- Reality: 94% of the "valid" range causes panics
- No documentation of actual working range
- Serious API design issue

### Fix
1. Add validation: `if id > MAX_ACTIVE_ID { return Err(...) }`
2. Fix mathematical model OR restrict MAX_ACTIVE_ID to working range

---

## Summary of Fixes Needed

### Immediate Fixes (Low Effort)
1. Fix MSB test assertion (Bug No. 1) - COMPLETED
2. Fix error message in test harness (Bug No. 2) - COMPLETED

### Medium Priority (Defensive Programming)
3. Add input validation for get_protocol_fee (Bug No. 3)
4. Replace unwrap() calls with proper error handling (Bug No. 4)

### High Priority (Design Issues)
5. Redesign mathematical model for extreme IDs (Bug No. 5)
6. Define and enforce consistent ID range validation (Bug No. 6)
7. Document actual working ranges clearly

## Conclusion

Found 6 bugs total. Two have been fixed in this PR (No. 1-2). The remaining four need attention - especially No. 4-6 which can crash in production.

The ID range issue is particularly bad: the API accepts 0 to 16,777,215 but only ~6% of that range actually works without panicking. This needs either documentation or a fix.
