### PR TITLE
Fix/aggregate fixes

### DIFF
--- a/saros-dlmm/src/amms/test_harness.rs
+++ b/saros-dlmm/src/amms/test_harness.rs
@@ -339,7 +339,7 @@ impl AmmTestHarnessProgramTest {
 
         let swap_ix = Instruction {
             program_id: saros::ID,
-            accounts: accounts,
+            accounts,
             data,
         };
 
@@ -620,16 +620,15 @@ impl AmmTestHarness {
             self.directory_name()
         ))
         .unwrap()
+        .flatten()
         {
-            if let Ok(entry) = entry {
-                if entry.ends_with("params.json") {
-                    continue;
-                }
-                let file = File::open(entry).unwrap();
-                let keyed_account: RpcKeyedAccount = serde_json::from_reader(file).unwrap();
-                let account: Account = UiAccount::decode(&keyed_account.account).unwrap();
-                account_map.insert(Pubkey::from_str(&keyed_account.pubkey).unwrap(), account);
+            if entry.ends_with("params.json") {
+                continue;
             }
+            let file = File::open(entry).unwrap();
+            let keyed_account: RpcKeyedAccount = serde_json::from_reader(file).unwrap();
+            let account: Account = UiAccount::decode(&keyed_account.account).unwrap();
+            account_map.insert(Pubkey::from_str(&keyed_account.pubkey).unwrap(), account);
         }
         account_map
     }
@@ -810,11 +809,9 @@ impl AmmTestHarness {
             self.directory_name()
         );
         let snapshot_path = Path::new(&snapshot_path_string);
-        if force {
-            if snapshot_path.exists() && snapshot_path.is_dir() {
-                // Remove the directory if it exists
-                remove_dir_all(snapshot_path)?;
-            }
+        if force && snapshot_path.exists() && snapshot_path.is_dir() {
+            // Remove the directory if it exists
+            remove_dir_all(snapshot_path)?;
         }
 
         create_dir_all(snapshot_path)?;

--- a/saros-sdk/src/math/fees.rs
+++ b/saros-sdk/src/math/fees.rs
@@ -1,4 +1,4 @@
-use solana_sdk::{pubkey::Pubkey};
+use solana_sdk::pubkey::Pubkey;
 use spl_token_2022::{
     self,
     extension::{self, BaseStateWithExtensions, StateWithExtensions, transfer_fee::TransferFee},
@@ -27,7 +27,7 @@ impl TokenTransferFee {
             self.epoch_transfer_fee_x = None;
         } else {
             let token_mint_unpacked =
-                StateWithExtensions::<spl_token_2022::state::Mint>::unpack(&mint_x_data)?;
+                StateWithExtensions::<spl_token_2022::state::Mint>::unpack(mint_x_data)?;
 
             if let Ok(transfer_fee_config) =
                 token_mint_unpacked.get_extension::<extension::transfer_fee::TransferFeeConfig>()
@@ -40,7 +40,7 @@ impl TokenTransferFee {
             self.epoch_transfer_fee_y = None;
         } else {
             let token_mint_unpacked =
-                StateWithExtensions::<spl_token_2022::state::Mint>::unpack(&mint_y_data)?;
+                StateWithExtensions::<spl_token_2022::state::Mint>::unpack(mint_y_data)?;
 
             if let Ok(transfer_fee_config) =
                 token_mint_unpacked.get_extension::<extension::transfer_fee::TransferFeeConfig>()
@@ -115,7 +115,7 @@ pub fn compute_transfer_fee_amount(
     token_mint_transfer_fee: Option<TransferFee>,
     transfer_amount: u64,
 ) -> Result<(u64, u64)> {
-    return compute_transfer_fee(token_mint_transfer_fee, transfer_amount);
+    compute_transfer_fee(token_mint_transfer_fee, transfer_amount)
 }
 
 pub fn compute_transfer_amount_for_expected_output(
@@ -125,5 +125,5 @@ pub fn compute_transfer_amount_for_expected_output(
     if expected_output == 0 {
         return Ok((0, 0));
     }
-    return compute_transfer_amount(token_mint_transfer_fee, expected_output);
+    compute_transfer_amount(token_mint_transfer_fee, expected_output)
 }

--- a/saros-sdk/src/math/swap_manager.rs
+++ b/saros-sdk/src/math/swap_manager.rs
@@ -1,7 +1,7 @@
 use crate::{
+    constants::MAX_BIN_CROSSING,
     errors::ErrorCode,
     state::{bin_array::BinArrayPair, pair::Pair},
-    constants::MAX_BIN_CROSSING,
 };
 use anyhow::Result;
 use jupiter_amm_interface::SwapMode;
@@ -63,9 +63,8 @@ pub fn get_swap_result(
 
                 if amount_in_left == 0 {
                     break;
-                } else {
-                    pair.move_active_id(swap_for_y)?;
                 }
+                pair.move_active_id(swap_for_y)?;
 
                 total_bin_used += 1;
             }
@@ -118,9 +117,9 @@ pub fn get_swap_result(
 
                 if amount_out_left == 0 {
                     break;
-                } else {
-                    pair.move_active_id(swap_for_y)?;
                 }
+                pair.move_active_id(swap_for_y)?;
+
                 total_bin_used += 1;
             }
 

--- a/saros-sdk/src/math/utils.rs
+++ b/saros-sdk/src/math/utils.rs
@@ -31,7 +31,10 @@ pub fn get_fee_for_amount(amount: u64, fee: u64) -> Result<u64> {
     let amount = u128::from(amount);
     let fee = u128::from(fee);
 
-    let denominator = u128::from(PRECISION) - fee;
+    let denominator = match u128::from(PRECISION).checked_sub(fee) {
+        Some(denom) if denom > 0 => denom,
+        _ => return Err(ErrorCode::AmountUnderflow.into()),
+    };
 
     let fee_for_amount = amount
         .checked_mul(fee)

--- a/saros-sdk/src/math/utils.rs
+++ b/saros-sdk/src/math/utils.rs
@@ -31,10 +31,9 @@ pub fn get_fee_for_amount(amount: u64, fee: u64) -> Result<u64> {
     let amount = u128::from(amount);
     let fee = u128::from(fee);
 
-    let denominator = match u128::from(PRECISION).checked_sub(fee) {
-        Some(denom) if denom > 0 => denom,
-        _ => return Err(ErrorCode::AmountUnderflow.into()),
-    };
+    let denominator = u128::from(PRECISION)
+        .checked_sub(fee)
+        .ok_or(ErrorCode::AmountUnderflow)?;
 
     let fee_for_amount = amount
         .checked_mul(fee)
@@ -43,7 +42,8 @@ pub fn get_fee_for_amount(amount: u64, fee: u64) -> Result<u64> {
         .ok_or(ErrorCode::AmountOverflow)?
         .checked_sub(1)
         .ok_or(ErrorCode::AmountUnderflow)?
-        / denominator;
+        .checked_div(denominator)
+        .ok_or(ErrorCode::DivideByZero)?;
 
     let fee_for_amount = u64::try_from(fee_for_amount).map_err(|_| ErrorCode::AmountOverflow)?;
 

--- a/saros-sdk/src/state/pair.rs
+++ b/saros-sdk/src/state/pair.rs
@@ -161,9 +161,7 @@ impl Clone for Pair {
 
 impl Pair {
     pub fn bin_array_index(&self) -> u32 {
-        let idx = self.active_id / BIN_ARRAY_SIZE;
-
-        idx
+        self.active_id / BIN_ARRAY_SIZE
     }
 
     pub fn resolve_mints(&self, input_mint: Pubkey, swap_mode: SwapMode) -> Result<bool> {
@@ -245,16 +243,16 @@ impl Pair {
     }
 
     pub fn get_protocol_share(&self) -> u64 {
-        self.static_fee_parameters.protocol_share as u64
+        u64::from(self.static_fee_parameters.protocol_share)
     }
 
     pub fn update_references(&mut self, block_timestamp: u64) -> Result<()> {
         let time_delta = block_timestamp - self.dynamic_fee_parameters.time_last_updated;
 
-        if time_delta >= self.static_fee_parameters.filter_period as u64 {
+        if time_delta >= u64::from(self.static_fee_parameters.filter_period) {
             self.dynamic_fee_parameters.id_reference = self.active_id;
 
-            if time_delta >= self.static_fee_parameters.decay_period as u64 {
+            if time_delta >= u64::from(self.static_fee_parameters.decay_period) {
                 self.dynamic_fee_parameters.volatility_reference = 0;
             } else {
                 self.update_volatility_reference()?;
@@ -273,7 +271,7 @@ impl Pair {
             volatility_accumulator
                 .checked_mul(self.static_fee_parameters.reduction_factor.into())
                 .ok_or(ErrorCode::AmountOverflow)?
-                / BASIS_POINT_MAX as u64,
+                / BASIS_POINT_MAX,
         )?;
 
         Ok(())
@@ -321,7 +319,6 @@ impl Pair {
     }
 
     fn move_active_id_right(&mut self) -> Result<()> {
-        // require!(self.active_id < MAX_ACTIVE_ID, ErrorCode::ActiveIdOverflow);
         if self.active_id >= MAX_ACTIVE_ID {
             Err(ErrorCode::ActiveIdOverflow)?;
         }

--- a/saros-sdk/src/utils/helper.rs
+++ b/saros-sdk/src/utils/helper.rs
@@ -15,7 +15,7 @@ pub fn get_bin_array_lower(
         &[
             b"bin_array".as_ref(),
             pair.as_ref(),
-            &(bin_array_index).to_le_bytes().as_ref(),
+            bin_array_index.to_le_bytes().as_ref(),
         ],
         program_id,
     );
@@ -31,7 +31,7 @@ pub fn get_bin_array_upper(
         &[
             b"bin_array".as_ref(),
             pair.as_ref(),
-            &(bin_array_index + 1).to_le_bytes().as_ref(),
+            (bin_array_index + 1).to_le_bytes().as_ref(),
         ],
         program_id,
     );


### PR DESCRIPTION
This pull request focuses on improving code clarity and safety across the Saros DLMM codebase. The main changes involve removing unnecessary references, simplifying expressions, and adding error handling to prevent panics and improve robustness. There are also updates for consistency in method calls and minor refactoring for idiomatic Rust usage.

### Error handling and safety improvements
* Added error checks in `get_fee_for_amount` to handle potential underflow and divide-by-zero cases, making the fee calculation more robust (`saros-sdk/src/math/utils.rs`). [[1]](diffhunk://#diff-3db0c85e837f70a9ef59bf850c6c9adcf61dceb9beae8922034ba4ca166a697aL34-R36) [[2]](diffhunk://#diff-3db0c85e837f70a9ef59bf850c6c9adcf61dceb9beae8922034ba4ca166a697aL43-R46)

### Simplification and idiomatic Rust updates
* Removed unnecessary references to slices in unpacking and deserialization calls throughout `saros-dlmm/src/lib.rs` and `saros-sdk/src/math/fees.rs`, making code more idiomatic and concise. [[1]](diffhunk://#diff-137cd7af7323eb23483fa9199828983e205e5405a3ed6528aa3ee73b4a00320aL81-R81) [[2]](diffhunk://#diff-137cd7af7323eb23483fa9199828983e205e5405a3ed6528aa3ee73b4a00320aL142-R142) [[3]](diffhunk://#diff-137cd7af7323eb23483fa9199828983e205e5405a3ed6528aa3ee73b4a00320aL167-R167) [[4]](diffhunk://#diff-137cd7af7323eb23483fa9199828983e205e5405a3ed6528aa3ee73b4a00320aL177-R177) [[5]](diffhunk://#diff-137cd7af7323eb23483fa9199828983e205e5405a3ed6528aa3ee73b4a00320aL203-R213) [[6]](diffhunk://#diff-0302e045e30f564f2da7d755e2d249dba3c80d01fd5f5c0b0a32311dac07e6dfL30-R30) [[7]](diffhunk://#diff-0302e045e30f564f2da7d755e2d249dba3c80d01fd5f5c0b0a32311dac07e6dfL43-R43)
* Refactored several functions to return values directly rather than using explicit `return` statements, streamlining the code flow (`saros-dlmm/src/lib.rs`, `saros-sdk/src/math/fees.rs`). [[1]](diffhunk://#diff-137cd7af7323eb23483fa9199828983e205e5405a3ed6528aa3ee73b4a00320aL124-R131) [[2]](diffhunk://#diff-0302e045e30f564f2da7d755e2d249dba3c80d01fd5f5c0b0a32311dac07e6dfL118-R118) [[3]](diffhunk://#diff-0302e045e30f564f2da7d755e2d249dba3c80d01fd5f5c0b0a32311dac07e6dfL128-R128)

### Code clarity and consistency
* Simplified expressions and removed redundant code in `Pair` methods, including direct return of calculated values and using `u64::from()` for type conversions (`saros-sdk/src/state/pair.rs`). [[1]](diffhunk://#diff-1afd1153b81ccb345f8a8b2553b7d13409c2d00089510b6c9099123f0d661beeL164-R164) [[2]](diffhunk://#diff-1afd1153b81ccb345f8a8b2553b7d13409c2d00089510b6c9099123f0d661beeL248-R255) [[3]](diffhunk://#diff-1afd1153b81ccb345f8a8b2553b7d13409c2d00089510b6c9099123f0d661beeL276-R274)
* Updated protocol share and reference period calculations to use more idiomatic type conversions (`saros-sdk/src/state/pair.rs`).
* Restored `move_active_id` calls to always execute after swaps, removing unnecessary branches for better code clarity (`saros-sdk/src/math/swap_manager.rs`). [[1]](diffhunk://#diff-bc00173566abff610e837fce657a0e533f43f60087b6e20ed956869d27a0cb20L66-R67) [[2]](diffhunk://#diff-bc00173566abff610e837fce657a0e533f43f60087b6e20ed956869d27a0cb20L121-R122)

### Minor refactoring and cleanup
* Cleaned up argument passing for bin array helper functions by removing redundant parentheses (`saros-sdk/src/utils/helper.rs`). [[1]](diffhunk://#diff-2e6c6dc23da56fff391d9ac996b0c97566c0ee135cfcc3cb51b55465832ac753L18-R18) [[2]](diffhunk://#diff-2e6c6dc23da56fff391d9ac996b0c97566c0ee135cfcc3cb51b55465832ac753L34-R34)
* Removed commented-out code and unnecessary blocks for improved readability (`saros-sdk/src/state/pair.rs`, `saros-dlmm/src/amms/test_harness.rs`). [[1]](diffhunk://#diff-1afd1153b81ccb345f8a8b2553b7d13409c2d00089510b6c9099123f0d661beeL324) [[2]](diffhunk://#diff-d4894a73bf69ab3a5f64ac6d49d4ea35ee683a5f57a27c20b4d4fe04011d2112L342-R342) [[3]](diffhunk://#diff-d4894a73bf69ab3a5f64ac6d49d4ea35ee683a5f57a27c20b4d4fe04011d2112L633)

### Directory and file handling improvements
* Improved directory removal logic to only execute when forced and the directory exists, preventing accidental deletions (`saros-dlmm/src/amms/test_harness.rs`).
* Added `.flatten()` to directory reading logic for better error handling and filtering (`saros-dlmm/src/amms/test_harness.rs`).